### PR TITLE
fix: fixed component will mount deprecated warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ export class PortalProvider extends React.Component {
     };
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this._emitter = new mitt();
   }
 
@@ -81,7 +81,7 @@ export class BlackPortal extends React.PureComponent {
     const { portalSet } = this.context;
     portalSet && portalSet(name, children);
   }
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     const oldProps = this.props;
     const { name, children } = newProps;
     const { portalSet } = this.context;
@@ -107,7 +107,7 @@ export class WhitePortal extends React.PureComponent {
     children?: *,
     childrenProps?: *,
   };
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { name } = this.props;
     const { portalSub } = this.context;
     portalSub && portalSub(name, this.forceUpdater);


### PR DESCRIPTION
This should fix the deprecation warning that shows up on development. It was fixed by running the `npx react-codemod rename-unsafe-lifecycles` command. 

This shouldn't be a permanent solution but will work for now 👍 